### PR TITLE
Revise proc_ops creation logic in ch2 proc kernel module exercise

### DIFF
--- a/ch2/hello.c
+++ b/ch2/hello.c
@@ -9,7 +9,7 @@
  * Operating System Concepts - 10th Edition
  * Copyright John Wiley & Sons - 2018
  */
-
+#include <linux/version.h>
 #include <linux/init.h>
 #include <linux/module.h>
 #include <linux/kernel.h>
@@ -26,11 +26,19 @@
  */
 static ssize_t proc_read(struct file *file, char *buf, size_t count, loff_t *pos);
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,6,0)
+#define HAVE_PROC_OPS
+#endif
+#ifdef HAVE_PROC_OPS
+static const struct proc_ops proc_ops = {
+	.proc_read = proc_read
+};
+#else
 static struct file_operations proc_ops = {
         .owner = THIS_MODULE,
         .read = proc_read,
 };
-
+#endif
 
 /* This function is called when the module is loaded. */
 static int proc_init(void)


### PR DESCRIPTION
Currently I'm using Linux kernel version 5.15.0 with ubuntu 22.04.1 LTS.
In chapter 2, exercise for creating proc file system kernel module, 
provided source code generates following error :

`error: passing argument 4 of ‘proc_create’ from incompatible pointer type [-Werror=incompatible-pointer-types]
   50 |         proc_create(PROC_NAME, 0, NULL, &proc_ops);
      |                                         ^~~~~~~~~
      |                                         |
      |                                         struct file_operations *
In file included from /home/lskhappychild/Desktop/Systems/Linux/ch2/hello.c:16:
./include/linux/proc_fs.h:110:122: note: expected ‘const struct proc_ops *’ but argument is of type ‘struct file_operations *’
  110 | t char *name, umode_t mode, struct proc_dir_entry *parent, const struct proc_ops *proc_ops);
      |                                                            ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~`

And this seems to happen due to Linux version compatibility.

So added part needed for compatibility with higher version linux kernel.